### PR TITLE
Allow commas in height searches

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -52,6 +52,8 @@ function getCurrentNetworkHashRateLoop() {
 
 function searchForTerm(term) {
   term = term.trim()
+    /* Allow commas in a height search */
+  term = term.replace(',', '')
   if (parseInt(term).toString() === term) {
     /* This should be height so we know to perform a search on height */
     $.ajax({


### PR DESCRIPTION
I prefer typing 123,456 to 123456. I am bad at counting. Untested.